### PR TITLE
Updated bower-discover dependency to a npm git

### DIFF
--- a/lib/buildConfig.js
+++ b/lib/buildConfig.js
@@ -1,6 +1,6 @@
 var cache = require('./cacheFiles.js');
 // Function to return the bower path by passing the bower package name
-var bowerPath = require('../../bower-discover');
+var bowerPath = require('bower-discover');
 
 var collectionDir;
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/blankbox/terra#readme",
   "dependencies": {
     "bower": "^1.7.9",
+    "bower-discover": "git+https://github.com/blankbox/bower-discover.git",
     "chokidar": "^1.6.0",
     "cors": "^2.8.1",
     "dotenv-safe": "^3.0.0",


### PR DESCRIPTION
Changed it so that you can install install without needing to have "bower-discover" already in the parent environment.